### PR TITLE
accepts options

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,13 +8,11 @@ var gutil = require('gulp-util'),
 
 /**
  * Exports function
- * @param "String" filename
  * @param {Object} options
  */
 
-module.exports = function(filename, options) {
-  options = options || {};
-  filename = filename || "index.html";
+module.exports = function(options) {
+  var filename = options && options.outputFile || 'index.html';
 
   return through.obj(function(file, enc, cb) {
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "gulp": "^3.8.11",
     "gulp-util": "^3.0.4",
+    "lodash": "^4.13.1",
     "styleguidejs": "^0.1.9",
     "through2": "^0.6.5"
   },


### PR DESCRIPTION
Fixes #2 and #3

It looks like a gulp module can only accept one argument.

Pull `filename` from `options.outputFile` and gracefully fallback to `'index.html` if no options object is provided.